### PR TITLE
Update HTML of order pages to be more user-friendly

### DIFF
--- a/InventoryXpert/Views/Order/Create.cshtml
+++ b/InventoryXpert/Views/Order/Create.cshtml
@@ -6,24 +6,24 @@
 
 <h1>Create</h1>
 
-<h4>Order</h4>
 <hr />
 <div class="row">
     <div class="col-md-4">
         <form asp-action="Create">
             <div asp-validation-summary="ModelOnly" class="text-danger"></div>
             <div class="form-group">
-                <label asp-for="ArrivalDate" class="control-label"></label>
+                <label asp-for="ArrivalDate" class="control-label">Arrival Date</label>
                 <input asp-for="ArrivalDate" class="form-control" />
                 <span asp-validation-for="ArrivalDate" class="text-danger"></span>
             </div>
             <div class="form-group">
-                <label asp-for="Shipped" class="control-label"></label>
-                <input asp-for="Shipped" class="form-control" />
+                <label asp-for="Shipped" class="control-label">Check if shipped: </label>
+                <input type="hidden" asp-for="Shipped" id="ShippedHidden" class="form-control" />
+                <input type="checkbox" id="ShippedCheckbox" />
                 <span asp-validation-for="Shipped" class="text-danger"></span>
             </div>
             <div class="form-group">
-                <label asp-for="PlacedDate" class="control-label"></label>
+                <label asp-for="PlacedDate" class="control-label">Placed On</label>
                 <input asp-for="PlacedDate" class="form-control" />
                 <span asp-validation-for="PlacedDate" class="text-danger"></span>
             </div>
@@ -45,4 +45,18 @@
 
 @section Scripts {
     @{await Html.RenderPartialAsync("_ValidationScriptsPartial");}
+
+    <script>
+        // Get the checkbox and hidden field elements
+        var shippedCheckbox = document.getElementById("ShippedCheckbox");
+        var shippedHidden = document.getElementById("ShippedHidden");
+
+        // Set initial value of hidden to false
+        shippedHidden.value = 0;
+
+        // Add event listener to update the hidden field value when checkbox state changes
+        shippedCheckbox.addEventListener("change", function () {
+            shippedHidden.value = this.checked ? 1 : 0;
+        });
+    </script>
 }

--- a/InventoryXpert/Views/Order/Delete.cshtml
+++ b/InventoryXpert/Views/Order/Delete.cshtml
@@ -6,13 +6,11 @@
 
 <h1>Delete</h1>
 
-<h3>Are you sure you want to delete this?</h3>
 <div>
-    <h4>Order</h4>
     <hr />
     <dl class="row">
         <dt class = "col-sm-2">
-            @Html.DisplayNameFor(model => model.ArrivalDate)
+            Arrival Date
         </dt>
         <dd class = "col-sm-10">
             @Html.DisplayFor(model => model.ArrivalDate)
@@ -21,10 +19,17 @@
             @Html.DisplayNameFor(model => model.Shipped)
         </dt>
         <dd class = "col-sm-10">
-            @Html.DisplayFor(model => model.Shipped)
+            @if (Model.Shipped == 1)
+            {
+                <text>Yes</text>
+            }
+            else
+            {
+                <text>No</text>
+            }
         </dd>
         <dt class = "col-sm-2">
-            @Html.DisplayNameFor(model => model.PlacedDate)
+            Placed On
         </dt>
         <dd class = "col-sm-10">
             @Html.DisplayFor(model => model.PlacedDate)

--- a/InventoryXpert/Views/Order/Details.cshtml
+++ b/InventoryXpert/Views/Order/Details.cshtml
@@ -7,11 +7,10 @@
 <h1>Details</h1>
 
 <div>
-    <h4>Order</h4>
     <hr />
     <dl class="row">
         <dt class = "col-sm-2">
-            @Html.DisplayNameFor(model => model.ArrivalDate)
+            Arrival Date
         </dt>
         <dd class = "col-sm-10">
             @Html.DisplayFor(model => model.ArrivalDate)
@@ -20,10 +19,17 @@
             @Html.DisplayNameFor(model => model.Shipped)
         </dt>
         <dd class = "col-sm-10">
-            @Html.DisplayFor(model => model.Shipped)
+            @if (Model.Shipped == 1)
+            {
+                <text>Yes</text>
+            }
+            else
+            {
+                <text>No</text>
+            }
         </dd>
         <dt class = "col-sm-2">
-            @Html.DisplayNameFor(model => model.PlacedDate)
+            Placed On
         </dt>
         <dd class = "col-sm-10">
             @Html.DisplayFor(model => model.PlacedDate)

--- a/InventoryXpert/Views/Order/Edit.cshtml
+++ b/InventoryXpert/Views/Order/Edit.cshtml
@@ -6,7 +6,6 @@
 
 <h1>Edit</h1>
 
-<h4>Order</h4>
 <hr />
 <div class="row">
     <div class="col-md-4">
@@ -14,17 +13,18 @@
             <div asp-validation-summary="ModelOnly" class="text-danger"></div>
             <input type="hidden" asp-for="Id" />
             <div class="form-group">
-                <label asp-for="ArrivalDate" class="control-label"></label>
+                <label asp-for="ArrivalDate" class="control-label">Arrival Date</label>
                 <input asp-for="ArrivalDate" class="form-control" />
                 <span asp-validation-for="ArrivalDate" class="text-danger"></span>
             </div>
             <div class="form-group">
-                <label asp-for="Shipped" class="control-label"></label>
-                <input asp-for="Shipped" class="form-control" />
+                <label asp-for="Shipped" class="control-label">Check if shipped: </label>
+                <input type="hidden" asp-for="Shipped" id="ShippedHidden" class="form-control" />
+                <input type="checkbox" id="ShippedCheckbox" />
                 <span asp-validation-for="Shipped" class="text-danger"></span>
             </div>
             <div class="form-group">
-                <label asp-for="PlacedDate" class="control-label"></label>
+                <label asp-for="PlacedDate" class="control-label">Placed On</label>
                 <input asp-for="PlacedDate" class="form-control" />
                 <span asp-validation-for="PlacedDate" class="text-danger"></span>
             </div>
@@ -46,4 +46,22 @@
 
 @section Scripts {
     @{await Html.RenderPartialAsync("_ValidationScriptsPartial");}
+
+    <script>
+        // Get the checkbox and hidden field elements
+        var shippedCheckbox = document.getElementById("ShippedCheckbox");
+        var shippedHidden = document.getElementById("ShippedHidden");
+
+        // Determine state of checkbox on first load
+        if (shippedHidden.value == 1) {
+            shippedCheckbox.checked = true;
+        } else {
+            shippedCheckbox.checked = false;
+        }
+
+        // Add event listener to update the hidden field value when checkbox state changes
+        shippedCheckbox.addEventListener("change", function () {
+            shippedHidden.value = this.checked ? 1 : 0;
+        });
+    </script>
 }

--- a/InventoryXpert/Views/Order/Index.cshtml
+++ b/InventoryXpert/Views/Order/Index.cshtml
@@ -4,7 +4,7 @@
     ViewData["Title"] = "Index";
 }
 
-<h1>Index</h1>
+<h1>Your Orders</h1>
 
 <p>
     <a class="button btn-create" asp-action="Create">Create New</a>
@@ -13,13 +13,15 @@
     <thead class="table-dark">
         <tr>
             <th>
-                @Html.DisplayNameFor(model => model.ArrivalDate)
+                @* @Html.DisplayNameFor(model => model.ArrivalDate) *@
+                Arrival Date
             </th>
             <th>
                 @Html.DisplayNameFor(model => model.Shipped)
             </th>
             <th>
-                @Html.DisplayNameFor(model => model.PlacedDate)
+                @* @Html.DisplayNameFor(model => model.PlacedDate) *@
+                Placed On
             </th>
             <th>
                 @Html.DisplayNameFor(model => model.Supplier)
@@ -34,7 +36,15 @@
                 @Html.DisplayFor(modelItem => item.ArrivalDate)
             </td>
             <td>
-                @Html.DisplayFor(modelItem => item.Shipped)
+                @* @Html.DisplayFor(modelItem => item.Shipped) *@
+                @if (item.Shipped == 1)
+                {
+                    <text>Yes</text>
+                }
+                else
+                {
+                    <text>No</text>
+                }
             </td>
             <td>
                 @Html.DisplayFor(modelItem => item.PlacedDate)


### PR DESCRIPTION
Updated HTML of order pages to be more user-friendly:
- Made naming of data more descriptive
- Made display of "Shipped" values be Yes or No instead of 1 or 0
- Deleted HTML not needed from automated creation